### PR TITLE
adding .gitignore of node_modules so npm install output is ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+


### PR DESCRIPTION
Now you can run `npm install` without modifying the git status.
