### PR TITLE
Add a call to done() at the end of an example test in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ describe('addOne Test', function() {
      'add-one'
    ], function(AddOne) {
      chai.assert.equal(AddOne.addOne(1), 2);
+     
+     done();
    });
  });
 });


### PR DESCRIPTION
The description of the example says `done()` gets called, but it doesn't! :confounded: 
